### PR TITLE
Launch test script in Docker container

### DIFF
--- a/docker_scripts/launch.py
+++ b/docker_scripts/launch.py
@@ -1,0 +1,25 @@
+#!/usr/bin/env python
+
+from __future__ import print_function
+import subprocess
+import sys
+import os
+
+if not len(sys.argv) > 1:
+    print("usage: launch.py filename.py")
+    sys.exit(-1)
+
+file_to_launch = sys.argv[1]
+if not os.path.exists(file_to_launch):
+    print("Cannot find script to launch")
+    sys.exit(-1)
+
+args = ['python'] + sys.argv[1:]
+print("Launching ", ' '.join(args))
+err = subprocess.call(args)
+
+if err == 0:
+    print("Script completed successfully.  Stopping supervisord.")
+    subprocess.call(["supervisorctl", "shutdown"])
+else:
+    sys.exit(err)

--- a/docker_scripts/run_disco_test.py
+++ b/docker_scripts/run_disco_test.py
@@ -1,14 +1,16 @@
+#!/usr/bin/env python
+
 # docker_featurize.py
 
 # to be run from INSIDE a docker container
 
+from __future__ import print_function
 import subprocess
 import sys
 import os
 sys.path.append("/home/mltsp/mltsp")
 #import build_rf_model
 from subprocess import Popen, PIPE, call
-import cPickle
 import time
 
 # ----
@@ -35,18 +37,18 @@ def disco_word_count():
 
 
 def disco_test():
-    print "*" * 80
-    print "Disco Test"
-    print "*" * 80
+    print("*" * 80)
+    print("Disco Test")
+    print("*" * 80)
 
     process = Popen(["disco", "status"], stdout=PIPE, stderr=PIPE)
     stdout, stderr = process.communicate()
-    print "-> disco status", stdout, stderr
+    print("-> disco status", stdout, stderr)
 
     time.sleep(2)
 
     if "stopped" in str(stdout):
-        print "Error: disco not running"
+        print("Error: disco not running")
         sys.exit(-1)
 
     elif "running" in str(stdout):
@@ -68,4 +70,4 @@ def disco_test():
 
 if __name__=="__main__":
     results_str = disco_test()
-    print results_str
+    print(results_str)

--- a/dockerfiles/base_disco/Dockerfile
+++ b/dockerfiles/base_disco/Dockerfile
@@ -8,18 +8,17 @@ ENV DEBIAN_FRONTEND noninteractive
 RUN apt-get install -y wget curl erlang git make openssh-server supervisor
 
 ## add user for disco
-RUN adduser --system disco --shell /bin/sh
+RUN adduser --system disco --shell /bin/bash
 
 ## setup ssh for disco
 RUN echo root:disco | chpasswd
 RUN mkdir -p /var/run/sshd
 
 ## passwordless login for disco
-RUN mkdir -p /home/disco/.ssh
-RUN ssh-keygen -N '' -f /home/disco/.ssh/id_dsa
-RUN cat /home/disco/.ssh/id_dsa.pub >> /home/disco/.ssh/authorized_keys
-RUN echo -n "localhost" > /home/disco/.ssh/known_hosts
-RUN ssh-keyscan -H localhost >> /home/disco/.ssh/known_hosts
+RUN mkdir -p /home/disco/.ssh && rm /home/disco/.ssh/*
+RUN ssh-keygen -t dsa -f /home/disco/.ssh/id_dsa
+RUN cat /home/disco/.ssh/id_dsa.pub > /home/disco/.ssh/authorized_keys
+RUN /usr/sbin/sshd && ssh-keyscan -H localhost > /home/disco/.ssh/known_hosts
 RUN chown disco -R /home/disco/.ssh
 
 ## install disco
@@ -33,8 +32,8 @@ ADD disco_8989.config /disco/root/disco_8989.config
 ENV PYTHONPATH /disco/lib
 
 ## configure the supervisor which will start ssh, docker & disco
-ADD supervisor.conf /etc/supervisor/conf.d/disco.conf
+ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
 EXPOSE 22
 EXPOSE 8990
 EXPOSE 8989
-CMD ["/usr/bin/supervisord"]
+CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/dockerfiles/base_disco/supervisord.conf
+++ b/dockerfiles/base_disco/supervisord.conf
@@ -1,6 +1,17 @@
 [supervisord]
 nodaemon=true
 
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
+
 [program:sshd]
 command=/usr/sbin/sshd -D
 

--- a/dockerfiles/disco_test/Dockerfile
+++ b/dockerfiles/disco_test/Dockerfile
@@ -4,8 +4,13 @@ RUN useradd -ms /bin/bash mltsp
 ENV HOME /home/mltsp
 WORKDIR /home/mltsp
 
-RUN ssh-keyscan -H localhost > /home/disco/.ssh/known_hosts
-RUN ln -s /home/disco/.ssh .
+RUN mkdir -p /home/disco/.ssh && rm /home/disco/.ssh/*
+RUN ssh-keygen -t dsa -f /home/disco/.ssh/id_dsa
+RUN cat /home/disco/.ssh/id_dsa.pub > /home/disco/.ssh/authorized_keys
+RUN /usr/sbin/sshd && ssh-keyscan -H localhost > /home/disco/.ssh/known_hosts
+RUN chown disco -R /home/disco/.ssh
 
+RUN rm /etc/supervisor/conf.d/*
 ADD supervisord.conf /etc/supervisor/conf.d/supervisord.conf
+
 CMD ["/usr/bin/supervisord", "-c", "/etc/supervisor/conf.d/supervisord.conf"]

--- a/dockerfiles/disco_test/supervisord.conf
+++ b/dockerfiles/disco_test/supervisord.conf
@@ -1,6 +1,17 @@
 [supervisord]
-nodaemon=true
+nodaemon=True
 loglevel=debug
+
+[unix_http_server]
+file=/var/run/supervisor.sock
+chmod=0700
+
+[supervisorctl]
+serverurl=unix:///var/run/supervisor.sock
+
+[rpcinterface:supervisor]
+supervisor.rpcinterface_factory = supervisor.rpcinterface:make_main_rpcinterface
+
 
 [program:sshd]
 command=/usr/sbin/sshd -D
@@ -11,4 +22,6 @@ user=disco
 environment=HOME="/home/disco"
 
 [program:test]
-command=/usr/bin/python /home/mltsp/mltsp/docker_scripts/run_disco_test.py
+command=python launch.py run_disco_test.py
+directory=/home/mltsp/mltsp/docker_scripts
+autorestart=unexpected


### PR DESCRIPTION
- Add script to launch worker and then abort by killing supervisord.
- Fix SSH passwordless login.
