### PR TITLE
Fix casper install bug caused by remote repo rename

### DIFF
--- a/tools/casper_install.sh
+++ b/tools/casper_install.sh
@@ -10,7 +10,7 @@ if [[ -d "casperjs" ]]; then
 else
     echo "Installing CasperJS into $EXTERNAL_DIR"
     echo
-    wget https://github.com/n1k0/casperjs/tarball/master -O - | tar -xz
-    mv n1k0-casperjs-* casperjs
+    wget https://github.com/casperjs/casperjs/tarball/master -O - | tar -xz
+    mv casperjs-casperjs-* casperjs
 fi
 


### PR DESCRIPTION
[casperjs](https://github.com/n1k0/casperjs) is now under the `casperjs` organization instead of `n1k0` so the source is extracted to a different path.