### PR TITLE
Replace netCDF4 with h5netcdf

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -54,7 +54,6 @@ addons:
     - libfreetype6-dev
     - libxft-dev
     - libhdf5-serial-dev
-    - libnetcdf-dev
 
 env:
     global:

--- a/cesium/featurize.py
+++ b/cesium/featurize.py
@@ -146,7 +146,7 @@ def load_and_store_feature_data(features_path, output_path):
     meta_feature_dicts = meta_features.to_dict(orient='record')
     featureset = assemble_featureset([], targets=targets,
                                      meta_feature_dicts=meta_feature_dicts)
-    featureset.to_netcdf(output_path)
+    featureset.to_netcdf(output_path, engine='h5netcdf')
     return featureset
 
 
@@ -345,6 +345,6 @@ def featurize_ts_files(ts_paths, features_to_use, output_path=None,
     result = delayed(assemble_featureset, pure=True)(all_features, all_time_series)
     fset = result.compute(get=scheduler)
     if output_path:
-        fset.to_netcdf(output_path)
+        fset.to_netcdf(output_path, engine='h5netcdf')
 
     return fset

--- a/cesium/tests/test_featurize.py
+++ b/cesium/tests/test_featurize.py
@@ -44,7 +44,7 @@ def test_already_featurized_data():
     assert("amplitude" in fset)
     assert(all(class_name in ['class1', 'class2', 'class3']
                for class_name in fset['target']))
-    with xr.open_dataset(fset_path) as loaded:
+    with xr.open_dataset(fset_path, engine='h5netcdf') as loaded:
         assert("std_err" in loaded)
         assert("amplitude" in loaded)
         assert(all(class_name in ['class1', 'class2', 'class3']

--- a/doc/install.md
+++ b/doc/install.md
@@ -5,10 +5,6 @@ The latest version of `cesium` can be installed via `pip`:
 pip install cesium
 ```
 
-*Note:* We depend on NetCDF4, which currently has no Linux wheel, so tries to
-compile itself.  You may therefore need to install the netcdf4 headers and
-library separately.
-
 The cesium library has the following dependencies:
 - [numpy](http://www.numpy.org/)
 - [scipy](http://www.scipy.org/)
@@ -17,7 +13,6 @@ The cesium library has the following dependencies:
 - [cython](http://cython.org/)
 - [dask](http://dask.pydata.org/)
 - [xarray](http://xarray.pydata.org/)
-- [NetCDF4](http://unidata.github.io/netcdf4-python/)
 
 For parallel processing, you will also need:
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,6 +6,6 @@ dask
 toolz
 xarray>=0.8.1
 gatspy>=0.3.0
-netCDF4
 cloudpickle
 joblib
+-e git://github.com/shoyer/h5netcdf.git#egg=h5netcdf


### PR DESCRIPTION
No more segfaults...?

Should work pending shoyer/h5netcdf#24. Currently I've changed our `requirements.txt` to point to `h5netcdf:master`; can change this to `>=0.3.1` once a release is made.