### PR TITLE
Use `sphinx_gallery` instead of markdown for examples

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -21,17 +21,5 @@ install:
 doc_reqs:
 	pip install -q -r requirements.docs.txt
 
-MARKDOWNS = $(wildcard $(EXAMPLE_DIR)/*Example.md)
-NOTEBOOKS = $(patsubst %Example.md, %Example.ipynb, $(MARKDOWNS))
-MD_OUTPUTS = $(patsubst %.md, %_output.md, $(MARKDOWNS))
-
-%Example.ipynb:%Example.md
-	notedown $< > $@
-	jupyter nbconvert --execute --inplace $@ --ExecutePreprocessor.timeout=-1
-
-%_output.md:%.ipynb
-	jupyter nbconvert --to=mdoutput --output=`basename $@` --output-dir=$(EXAMPLE_DIR) $<
-
-html: | doc_reqs $(NOTEBOOKS) $(MD_OUTPUTS)
+html: | doc_reqs
 	export SPHINXOPTS=-W; make -C doc html
-	cp $(EXAMPLE_DIR)/*.ipynb doc/_build/html/examples/

--- a/doc/Makefile
+++ b/doc/Makefile
@@ -52,6 +52,8 @@ clean:
 	rm -rf $(BUILDDIR)/*
 	rm -rf api/
 	rm -rf examples/*output* examples/*ipynb
+	rm -rf auto_examples
+	rm -rf modules/
 
 html:
 	$(SPHINXBUILD) -b html $(ALLSPHINXOPTS) $(BUILDDIR)/html

--- a/doc/_static/output_cells.css
+++ b/doc/_static/output_cells.css
@@ -1,3 +1,13 @@
-div.highlight-output {
+.sphx-glr-script-out {
     background-color: #EAEAF2;
+}
+
+.sphx-glr-script-out .highlight pre {
+    background-color: #EAEAF2;
+}
+
+div.sphx-glr-download a {
+    background-color: #EAEAF2;
+    border-color: #EAEAF2;
+    background-image: none;
 }

--- a/doc/conf.py
+++ b/doc/conf.py
@@ -39,7 +39,14 @@ extensions = [
 #    'plot2rst',
 #    'sphinx.ext.intersphinx',
 #    'sphinx.ext.linkcode',
+    'sphinx_gallery.gen_gallery'
 ]
+
+sphinx_gallery_conf = {
+    # path to your examples scripts
+    'examples_dirs' : '../examples',
+    # path where to save gallery generated examples
+    'gallery_dirs'  : 'auto_examples'}
 
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['_templates']

--- a/doc/index.rst
+++ b/doc/index.rst
@@ -6,7 +6,7 @@ Machine Learning Time-Series Platform Documentation
 
    Installation <install>
    Time-Series Features <feature_table>
-   Examples <examples>
+   Examples <auto_examples/index>
    API <api/api>
 
 .. Indices and tables

--- a/examples/README.txt
+++ b/examples/README.txt
@@ -1,10 +1,7 @@
+.. _examples-index:
+
 Examples
 ========
 
 Examples of how to use the :code:`cesium` library to perform machine learning
 for time series data.
-
-EEG Example
------------
-
-:doc:`examples/EEG_Example_output`

--- a/examples/plot_EEG_Example.py
+++ b/examples/plot_EEG_Example.py
@@ -1,10 +1,11 @@
-# Epilepsy Detection Using EEG Data
+"""
+=================================
+Epilepsy Detection Using EEG Data
+=================================
 
-> IPython notebook: <a href="EEG_Example.ipynb" download="EEG_Example.ipynb">download</a>
-
-In this example we'll use the [`cesium`](http://github.com/cesium-ml/cesium/) library to compare
+In this example we'll use the |cesium|_ library to compare
 various techniques for epilepsy detection using a classic EEG time series dataset from
-[Andrzejak et al.](http://www.meb.uni-bonn.de/epileptologie/science/physik/eegdata.html).
+`Andrzejak et al.  <http://www.meb.uni-bonn.de/epileptologie/science/physik/eegdata.html>`_.
 The raw data are separated into five classes: Z, O, N, F, and S; we will consider a
 three-class classification problem of distinguishing normal (Z, O), interictal (N, F), and
 ictal (S) signals.
@@ -17,8 +18,10 @@ holdout set and comparing them to the true class labels.
 
 First, we'll load the data and inspect a representative time series from each class:
 
-```python
-%matplotlib inline
+.. |cesium| replace:: ``cesium``
+.. _cesium: https://github.com/cesium-ml/cesium
+"""
+
 import numpy as np
 import matplotlib.pyplot as plt
 import seaborn; seaborn.set()
@@ -38,21 +41,25 @@ for label, subplot in zip(np.unique(eeg["classes"]), ax):
     i = np.where(eeg["classes"] == label)[0][0]
     subplot.plot(eeg["times"][i], eeg["measurements"][i])
     subplot.set(xlabel="time (s)", ylabel="signal", title=label)
-```
 
-## Featurization
-Once the data is loaded, we can generate features for each time series using the
-[`cesium.featurize`](https://cesium.readthedocs.org/en/latest/api/cesium.featurize.html)
-module. The `featurize` module includes many built-in choices of features which can be applied
-for any type of time series data; here we've chosen a few generic features that do not have
-any special biological significance.
 
-By default, the time series will featurized in parallel using the
-`dask.multiprocessing` scheduler; other approaches, including serial and
-distributed approaches, can be implemented by passing in other `dask`
-schedulers as the `get` argument to `featurize_time_series`.
+###############################################################################
+# Featurization
+# -------------
+# Once the data is loaded, we can generate features for each time series using the
+# |cesium.featurize|_ module. The ``featurize`` module includes many built-in
+# choices of features which can be applied for any type of time series data;
+# here we've chosen a few generic features that do not have any special
+# biological significance.
+# 
+# By default, the time series will featurized in parallel using the
+# ``dask.multiprocessing`` scheduler; other approaches, including serial and
+# distributed approaches, can be implemented by passing in other ``dask``
+# schedulers as the ``get`` argument to ``featurize_time_series``.
+#
+# .. |cesium.featurize| replace:: ``cesium.featurize``
+# .. _cesium.featurize: http://cesium.ml/docs/api/cesium.featurize.html
 
-```python
 from cesium import featurize
 features_to_use = ['amplitude',
                    'percent_beyond_1_std',
@@ -71,26 +78,26 @@ fset_cesium = featurize.featurize_time_series(times=eeg["times"],
                                               features_to_use=features_to_use,
                                               targets=eeg["classes"])
 print(fset_cesium)
-```
 
-The output of
-[`featurize_time_series`](https://cesium.readthedocs.org/en/latest/api/cesium.featurize.html#cesium.featurize.featurize_time_series)
-is an `xarray.Dataset` which contains all the feature information needed to train a machine
-learning model: feature values are stored as data variables, and the time series index/class
-label are stored as coordinates (a `channel` coordinate will also be used later for
-multi-channel data).
+###############################################################################
+# The output of ``featurize_time_series`` is an ``xarray.Dataset`` which contains all
+# the feature information needed to train a machine learning model: feature
+# values are stored as data variables, and the time series index/class label are
+# stored as coordinates (a ``channel`` coordinate will also be used later for
+# multi-channel data).
 
-### Custom feature functions
-Custom feature functions not built into `cesium` may be passed in using the
-`custom_functions` keyword, either as a dictionary `{feature_name: function}`, or as a
-[dask graph](http://dask.pydata.org/en/latest/custom-graphs.html). Functions should take
-three arrays `times, measurements, errors` as inputs; details can be found in the
-`cesium.featurize`
-[documentation](https://cesium.readthedocs.org/en/latest/api/cesium.featurize.html).
-Here we'll compute five standard features for EEG analysis provided by [Guo et al.
-(2012)](http://linkinghub.elsevier.com/retrieve/pii/S0957417411003253):
+###############################################################################
+# Custom feature functions
+# ~~~~~~~~~~~~~~~~~~~~~~~~
+# Custom feature functions not built into ``cesium`` may be passed in using the
+# ``custom_functions`` keyword, either as a dictionary ``{feature_name: function}``, or as a
+# `dask graph <http://dask.pydata.org/en/latest/custom-graphs.html>`_. Functions should take
+# three arrays ``times, measurements, errors`` as inputs; details can be found in the
+# ``cesium.featurize``
+# `documentation <http://cesium.ml/docs/api/cesium.featurize.html>`_.
+# Here we'll compute five standard features for EEG analysis provided by
+# `Guo et al. (2012) # <http://linkinghub.elsevier.com/retrieve/pii/S0957417411003253)>`_:
 
-```python
 import numpy as np
 import scipy.stats
 
@@ -108,12 +115,11 @@ def abs_diffs_signal(t, m, e):
 
 def skew_signal(t, m, e):
     return scipy.stats.skew(m)
-```
 
-Now we'll pass the desired feature functions as a dictionary via the `custom_functions`
-keyword argument.
+###############################################################################
+# Now we'll pass the desired feature functions as a dictionary via the
+# ``custom_functions`` keyword argument.
 
-```python
 guo_features = {
     'mean': mean_signal,
     'std': std_signal,
@@ -127,18 +133,17 @@ fset_guo = featurize.featurize_time_series(times=eeg["times"], values=eeg["measu
                                            features_to_use=list(guo_features.keys()),
                                            custom_functions=guo_features)
 print(fset_guo)
-```
 
-### Multi-channel time series
-The EEG time series considered here consist of univariate signal measurements along a
-uniform time grid. But
-[`featurize_time_series`](https://cesium.readthedocs.org/en/latest/api/cesium.featurize.html#cesium.featurize.featurize_time_series)
-also accepts multi-channel data; to demonstrate this, we will decompose each signal into
-five frequency bands using a discrete wavelet transform as suggested by [Subasi
-(2005)](http://www.sciencedirect.com/science/article/pii/S0957417404001745), and then
-featurize each band separately using the five functions from above.
+###############################################################################
+# Multi-channel time series
+# ~~~~~~~~~~~~~~~~~~~~~~~~~
+# The EEG time series considered here consist of univariate signal measurements along a
+# uniform time grid. But ``featurize_time_series`` also accepts multi-channel
+# data; to demonstrate this, we will decompose each signal into five frequency
+# bands using a discrete wavelet transform as suggested by
+# `Subasi (2005) <http://www.sciencedirect.com/science/article/pii/S0957417404001745>`_,
+# and then featurize each band separately using the five functions from above.
 
-```python
 import pywt
 
 n_channels = 5
@@ -149,32 +154,32 @@ fset_dwt = featurize.featurize_time_series(times=None, values=eeg["dwts"], error
                                            targets=eeg["classes"],
                                            custom_functions=guo_features)
 print(fset_dwt)
-```
 
-The output featureset has the same form as before, except now the `channel` coordinate is
-used to index the features by the corresponding frequency band. The functions in
-[`cesium.build_model`](https://cesium.readthedocs.org/en/latest/api/cesium.build_model.html)
-and [`cesium.predict`](https://cesium.readthedocs.org/en/latest/api/cesium.predict.html)
-all accept featuresets from single- or multi-channel data, so no additional steps are
-required to train models or make predictions for multichannel featuresets using the
-`cesium` library.
+###############################################################################
+# The output featureset has the same form as before, except now the ``channel``
+# coordinate is used to index the features by the corresponding frequency band.
+# The functions in ``cesium.build_model`` and ``cesium.predict`` all accept
+# featuresets from single- or multi-channel data, so no additional steps are
+# required to train models or make predictions for multichannel featuresets
+# using the ``cesium`` library.
 
-## Model Building
-Model building in `cesium` is handled by the
-[`build_model_from_featureset`](https://cesium.readthedocs.org/en/latest/api/cesium.build_model.html#cesium.build_model.build_model_from_featureset)
-function in the `cesium.build_model` submodule. The featureset output by
-[`featurize_time_series`](https://cesium.readthedocs.org/en/latest/api/cesium.featurize.html#cesium.featurize.featurize_time_series)
-contains both the feature and target information needed to train a
-model; `build_model_from_featureset` is simply a wrapper that calls the `fit` method of a
-given `scikit-learn` model with the appropriate inputs. In the case of multichannel
-features, it also handles reshaping the featureset into a (rectangular) form that is
-compatible with `scikit-learn`.
+###############################################################################
+# Model Building
+# --------------
+# Model building in ``cesium`` is handled by the ``build_model_from_featureset``
+# function in the ``cesium.build_model`` submodule. The featureset output by
+# ``featurize_time_series`` contains both the feature and target information
+# needed to train a model; ``build_model_from_featureset`` is simply a wrapper
+# that calls the ``fit`` method of a given ``scikit-learn`` model with the
+# appropriate inputs. In the case of multichannel features, it also handles
+# reshaping the featureset into a (rectangular) form that is compatible with
+# ``scikit-learn``.
+#
+# For this example, we'll test a random forest classifier for the built-in
+# ``cesium`` features, and a 3-nearest neighbors classifier for the others, as
+# suggested by
+# `Guo et al. (2012) <http://linkinghub.elsevier.com/retrieve/pii/S0957417411003253>`_.
 
-For this example, we'll test a random forest classifier for the built-in `cesium` features,
-and a 3-nearest neighbors classifier for the others, as suggested by [Guo et al.
-(2012)](http://linkinghub.elsevier.com/retrieve/pii/S0957417411003253).
-
-```python
 from cesium.build_model import build_model_from_featureset
 from sklearn.ensemble import RandomForestClassifier
 from sklearn.neighbors import KNeighborsClassifier
@@ -194,16 +199,15 @@ model_guo = build_model_from_featureset(fset_guo.isel(name=train),
 model_dwt = build_model_from_featureset(fset_dwt.isel(name=train),
                                         KNeighborsClassifier(),
                                         params_to_optimize=knn_param_grid)
-```
 
-## Prediction
-Making predictions for new time series based on these models follows the same pattern:
-first the time series are featurized using
-[`featurize_timeseries`](https://cesium.readthedocs.org/en/latest/api/cesium.featurize.html#cesium.featurize.featurize_time_series),
-and then predictions are made based on these features using
-[`predict.model_predictions`](https://cesium.readthedocs.org/en/latest/api/cesium.predict.html#cesium.predict.model_predictions),
+###############################################################################
+# Prediction
+# ----------
+# Making predictions for new time series based on these models follows the same
+# pattern: first the time series are featurized using ``featurize_time_series``,
+# and then predictions are made based on these features using
+# ``predict.model_predictions``.
 
-```python
 from sklearn.metrics import accuracy_score
 from cesium.predict import model_predictions
 
@@ -220,13 +224,13 @@ print("Guo et al. features: training accuracy={:.2%}, test accuracy={:.2%}".form
 print("Wavelet transform features: training accuracy={:.2%}, test accuracy={:.2%}".format(
           accuracy_score(preds_dwt.prediction.values[train], eeg["classes"][train]),
           accuracy_score(preds_dwt.prediction.values[test], eeg["classes"][test])))
-```
 
-The workflow presented here is intentionally simplistic and omits many important steps
-such as feature selection, model parameter selection, etc., which may all be
-incorporated just as they would for any other `scikit-learn` analysis.
-But with essentially three function calls (`featurize_time_series`,
-`build_model_from_featureset`, and `model_predictions`), we are able to build a
-model from a set of time series and make predictions on new, unlabeled data. In
-upcoming posts we'll introduce the web frontend for `cesium` and describe how
-the same analysis can be performed in a browser with no setup or coding required.
+###############################################################################
+# The workflow presented here is intentionally simplistic and omits many important steps
+# such as feature selection, model parameter selection, etc., which may all be
+# incorporated just as they would for any other ``scikit-learn`` analysis.
+# But with essentially three function calls (``featurize_time_series``,
+# ``build_model_from_featureset``, and ``model_predictions``), we are able to build a
+# model from a set of time series and make predictions on new, unlabeled data. In
+# upcoming posts we'll introduce the web frontend for ``cesium`` and describe how
+# the same analysis can be performed in a browser with no setup or coding required.

--- a/requirements.docs.txt
+++ b/requirements.docs.txt
@@ -6,9 +6,9 @@ notedown
 ipython>=5.1.0
 notebook>=4.2.2
 ipykernel>=4.4.1
-nbconvert[execute]>=4.2.0
-jupytercontrib>=0.0.5
 matplotlib==1.5.0
 seaborn
 pywavelets
 tabulate
+sphinx-gallery
+pillow


### PR DESCRIPTION
Should make using `doctr` easier since everything will be executed by `sphinx` instead of via a separate external pipeline (see https://github.com/cesium-ml/cesium/pull/216).