### PR TITLE
Optimize `delta_t_hist` using convolutions

### DIFF
--- a/cesium/__init__.py
+++ b/cesium/__init__.py
@@ -4,3 +4,5 @@ See http://cesium.ml for more information.
 """
 
 from .version import version as __version__
+from . import (build_model, data_management, featurize, features, predict,
+               time_series, transformation)

--- a/cesium/features/cadence_features.py
+++ b/cesium/features/cadence_features.py
@@ -75,7 +75,7 @@ def peak_ratio(peaks, i, j):
     if len(peaks) > i and len(peaks) > j:
         return peaks[i][1] / peaks[j][1]
     else:
-        return None
+        return np.nan
 
 
 def peak_bin(peaks, i):
@@ -84,4 +84,4 @@ def peak_bin(peaks, i):
     if len(peaks) > i:
         return peaks[i][0]
     else:
-        return None
+        return np.nan

--- a/cesium/features/cadence_features.py
+++ b/cesium/features/cadence_features.py
@@ -19,14 +19,19 @@ def cad_prob(cads, time):
     return stats.percentileofscore(cads, float(time) / (24.0 * 60.0)) / 100.0
 
 
-def delta_t_hist(t, nbins=50):
-    """Build histogram of all possible delta_t's without storing every value"""
-    hist = np.zeros(nbins, dtype='int')
-    bins = np.linspace(0, max(t) - min(t), nbins + 1)
-    for i in range(len(t)):
-        hist += np.histogram(t[i] - t[:i], bins=bins)[0]
-        hist += np.histogram(t[i + 1:] - t[i], bins=bins)[0]
-    return hist / 2  # Double-counts since we loop over every pair twice
+def delta_t_hist(t, nbins=50, conv_oversample=50):
+    """Build histogram of all possible |t_i - t_j|'s.
+
+    For efficiency, we construct the histogram via a convolution of the PDF
+    rather than by actually computing all the differences. For better accuracy
+    we use a factor `conv_oversample` more bins when performing the convolution
+    and then aggregate the result to have `nbins` total values.
+    """
+    f, x = np.histogram(t, bins=conv_oversample * nbins)
+    g = np.convolve(f, f[::-1])[len(f) - 1:]  # Discard negative domain
+    g[0] -= len(t)  # First bin is double-counted because of i=j terms
+    hist = g.reshape((-1, conv_oversample)).sum(axis=1)  # Combine bins
+    return hist
 
 
 def normalize_hist(hist, total_time):

--- a/cesium/features/graphs.py
+++ b/cesium/features/graphs.py
@@ -47,7 +47,6 @@ feature_categories = {
         'cad_probs_500000','cad_probs_1000000','cad_probs_5000000',
         'cad_probs_10000000','med_double_to_single_step',
         'avg_double_to_single_step','std_double_to_single_step',
-        'all_times_hist_peak_val','all_times_hist_peak_bin',
         'all_times_nhist_numpeaks','all_times_nhist_peak_val',
         'all_times_nhist_peak_1_to_2','all_times_nhist_peak_1_to_3',
         'all_times_nhist_peak_2_to_3','all_times_nhist_peak_1_to_4',
@@ -134,10 +133,6 @@ dask_feature_graph = {
     'delta_t_hist': (delta_t_hist, 't'),
     'delta_t_nhist': (normalize_hist, 'delta_t_hist', 'total_time'),
     'nhist_peaks': (find_sorted_peaks, 'delta_t_nhist'),
-    'all_times_hist_peak_val': (np.max, 'delta_t_hist'),
-    # Can''t' JSON serialize np.int64 under Python3 (yet?), cast as int first
-    'all_times_hist_peak_bin': (lambda x: int(np.argmax(x)),
-                                'delta_t_hist'),
     'all_times_nhist_numpeaks': (len, 'nhist_peaks'),
     'all_times_nhist_peak_val': (np.max, 'delta_t_nhist'),
     'all_times_nhist_peak_1_to_2': (peak_ratio, 'nhist_peaks', 1, 2),
@@ -272,9 +267,6 @@ extra_feature_docs = {
     'Median value of ratios (t[i+2] - t[i]) / (t[i+2] - t[i+1]).',
     'std_double_to_single_step':
     'Standard deviation of ratios (t[i+2] - t[i]) / (t[i+2] - t[i+1]).',
-    'all_times_hist_peak_val': 'Peak value of histogram of all possible delta_t\'s.',
-    'all_times_hist_peak_bin':
-    'Bin number of peak of of histogram of all possible delta_t\'s.',
     'all_times_nhist_numpeaks':
     'Number of peaks (local maxima) in histogram of all possible delta_t\'s.',
     'all_times_nhist_peak_val':
@@ -318,9 +310,6 @@ feature_tags = {
     'delta_t_hist': ['Astronomy', 'General', 'Cadence'],
     'delta_t_nhist': ['Astronomy', 'General', 'Cadence'],
     'nhist_peaks': ['Astronomy', 'General', 'Cadence'],
-    'all_times_hist_peak_val': ['Astronomy', 'General', 'Cadence'],
-    # Can''t' JSON serialize np.int64 under Python3 (yet?), cast as int first
-    'all_times_hist_peak_bin': ['Astronomy', 'General', 'Cadence'],
     'all_times_nhist_numpeaks': ['Astronomy', 'General', 'Cadence'],
     'all_times_nhist_peak_val': ['Astronomy', 'General', 'Cadence'],
     'all_times_nhist_peak_1_to_2': ['Astronomy', 'General', 'Cadence'],

--- a/cesium/features/tests/test_cadence_features.py
+++ b/cesium/features/tests/test_cadence_features.py
@@ -7,24 +7,24 @@ from cesium.features.tests.util import irregular_random
 
 def test_delta_t_hist():
     """Test histogram of all time lags."""
-    times, values, errors = irregular_random()
+    times, values, errors = irregular_random(500)
     delta_ts = [pair[1] - pair[0] for pair in itertools.combinations(times, 2)]
     nbins = 50
     bins = np.linspace(0, max(times) - min(times), nbins + 1)
-    npt.assert_allclose(cf.delta_t_hist(times, nbins), np.histogram(delta_ts,
-                                                                    bins=bins)[0])
+    npt.assert_allclose(cf.delta_t_hist(times, nbins),
+                        np.histogram(delta_ts, bins=bins)[0], atol=2)
 
 
 def test_normalize_hist():
     """Test normalization of histogram."""
-    times, values, errors = irregular_random()
+    times, values, errors = irregular_random(500)
     delta_ts = [pair[1] - pair[0] for pair in itertools.combinations(times, 2)]
     nbins = 50
     bins = np.linspace(0, max(times) - min(times), nbins + 1)
-    nhist = cf.normalize_hist(cf.delta_t_hist(times, nbins), max(times) -
-                              min(times))
-    npt.assert_allclose(nhist, np.histogram(delta_ts,
-                                            bins=bins, density=True)[0])
+    nhist = cf.normalize_hist(cf.delta_t_hist(times, nbins),
+                              max(times) - min(times))
+    npt.assert_allclose(nhist, np.histogram(delta_ts, bins=bins,
+                                            density=True)[0], atol=0.01)
 
 
 def test_find_sorted_peaks():

--- a/cesium/features/tests/test_cadence_features.py
+++ b/cesium/features/tests/test_cadence_features.py
@@ -51,9 +51,9 @@ def test_peak_ratio():
     x = np.array([0, 5, 2, 3, 1])
     peaks1 = cf.find_sorted_peaks(x)
     npt.assert_almost_equal(cf.peak_ratio(peaks1, 0, 1), 5 / 3)
-    assert cf.peak_ratio(peaks1, 1, 6) is None
+    assert cf.peak_ratio(peaks1, 1, 6) is np.nan
     peaks2 = []
-    assert cf.peak_ratio(peaks2, 1, 2) is None
+    assert cf.peak_ratio(peaks2, 1, 2) is np.nan
 
 
 def test_peak_bins():
@@ -63,4 +63,4 @@ def test_peak_bins():
     npt.assert_almost_equal(cf.peak_bin(peaks1, 0), 1)
     npt.assert_almost_equal(cf.peak_bin(peaks1, 1), 3)
     result1 = cf.peak_bin(peaks1, 6)
-    assert cf.peak_bin(peaks1, 6) is None
+    assert cf.peak_bin(peaks1, 6) is np.nan


### PR DESCRIPTION
26,244x faster for `n=41442`:

Old:
```
%time cf.delta_t_hist(t)
Wall time: 1min 56s
```

New:
```
%time cf.delta_t_hist(t)
Wall time: 4.42 ms
```