### PR TITLE
Do pip install of coverage during travis-ci run

### DIFF
--- a/.drone/travis_install.sh
+++ b/.drone/travis_install.sh
@@ -12,7 +12,8 @@ section_end "create.virtualenv"
 section "install.base.requirements"
 pip install --upgrade pip
 hash -d pip  # find upgraded pip
-pip install --retries 3 -q requests six python-dateutil nose nose-exclude mock
+pip install --retries 3 -q requests six python-dateutil nose nose-exclude \
+                           mock coverage
 section_end "install.base.requirements"
 
 


### PR DESCRIPTION
This is a requirement for nose to generate a coverage report, subsequently
uploaded to codecov.