### PR TITLE
Only deploy docs when on master

### DIFF
--- a/.drone/deploy_docs.sh
+++ b/.drone/deploy_docs.sh
@@ -4,7 +4,9 @@ set -e
 
 source ~/envs/cesium/bin/activate
 
-if [[ $DEPLOY_DOCS == 1 ]]
+if [[ $TRAVIS_PULL_REQUEST == false && \
+      $TRAVIS_BRANCH == "master" && \
+      $DEPLOY_DOCS == 1 ]]
 then
     pip install doctr
     doctr deploy --gh-pages-docs '.' --deploy-repo "cesium-ml/docs"


### PR DESCRIPTION
It looks like these checks were removed with the transition to doctr.  It did
not cause any problems, because the various branches do not have the tokens
required to push.  Still, for safety, add a check to ensure deploying only
from the master branch, and not from a PR.