### PR TITLE
Update load_featureset to handle filler strings for empty channel values

### DIFF
--- a/cesium/featurize.py
+++ b/cesium/featurize.py
@@ -441,7 +441,7 @@ def load_featureset(path):
     fset = pd.DataFrame.from_records(data.pop('features'),
                                      index=['feature', 'channel']).T
     features, channels = zip(*fset.columns)
-    channels = [int(c) if c != '' else '' for c in channels]
+    channels = [int(c) if str(c).isdigit() else '' for c in channels]
     fset.columns = pd.MultiIndex.from_tuples(list(zip(features, channels)),
                                              names=['feature', 'channel'])
 


### PR DESCRIPTION
When reading a CSV into a pandas DataFrame (`pd.read_csv`), empty channel values are filled with a string ("Unnamed ...") which, when saved and then loaded with `load_featureset`, breaks the type-casting of channel values from string to int, unless empty. This changes the check from whether it's empty to whether it's a digit, to handle the above-specified case.