### PR TITLE
Make SQR and SIGN static inline.

### DIFF
--- a/cesium/features/_eigs.h
+++ b/cesium/features/_eigs.h
@@ -1,10 +1,10 @@
 #include <math.h>
 
-inline double SQR(double a) {
+static inline double SQR(double a) {
     return (a == 0.0 ? 0.0 : a*a);
 }
 
-inline double SIGN(double a,double b) {
+static inline double SIGN(double a,double b) {
     return ((b) >= 0.0 ? fabs(a) : -fabs(a));
 }
 


### PR DESCRIPTION
From my limited understanding of C99 inline this is required, as no
`extern inline` is done for those symbols anywhere.