### PR TITLE
Dask version must be < 0.20.0

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.12.1
 scipy>=0.16.0
 scikit-learn>=0.18.1
 pandas>=0.17.0
-dask>=0.15.0
+dask>=0.15.0, <0.20.0
 toolz
 gatspy>=0.3.0
 cloudpickle


### PR DESCRIPTION
When using `pip install cesium`, by default dask 0.20.0 was installed.

In the dask 0.20.0 [changelog](http://docs.dask.org/en/latest/changelog.html) there is : 
> Raise an error on the use of the get= keyword and set_options

However, `featurize_time_series` and `featurize_ts_files` (maybe other functions) still use the `get` keyword, so we get the error :
> TypeError: The get= keyword has been removed.
> 
> Please use the scheduler= keyword instead with the name of
> the desired scheduler like 'threads' or 'processes'

The `requirements.txt` was changed to limit the dask version to one before 0.20.0

Now we only get a warning

> UserWarning: The get= keyword has been deprecated. Please use the scheduler= keyword instead with the name of the desired scheduler like 'threads' or 'processes'

PS: The warning appeared in dask 0.18.0, so we can set <0.18.0 if we don't want the warning