### PR TITLE
Compatibility with dask 0.20 : 'get' keyword replaced with 'scheduler'

### DIFF
--- a/cesium/featurize.py
+++ b/cesium/featurize.py
@@ -255,7 +255,7 @@ def featurize_time_series(times, values, errors=None, features_to_use=[],
                                                             raise_exceptions)
                     for ts in all_time_series]
     result = delayed(assemble_featureset, pure=True)(all_features, all_time_series)
-    return result.compute(get=scheduler)
+    return result.compute(scheduler=scheduler)
 
 
 def featurize_ts_files(ts_paths, features_to_use, custom_script_path=None,
@@ -316,7 +316,7 @@ def featurize_ts_files(ts_paths, features_to_use, custom_script_path=None,
     result = delayed(assemble_featureset, pure=True)(all_features,
                                                      meta_features_list=meta_feats,
                                                      names=names)
-    fset, labels = dask.compute(result, all_labels, get=scheduler)
+    fset, labels = dask.compute(result, all_labels, scheduler=scheduler)
 
     return fset, labels
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.12.1
 scipy>=0.16.0
 scikit-learn>=0.18.1
 pandas>=0.17.0
-dask>=0.15.0
+dask>=0.20.0
 toolz
 gatspy>=0.3.0
 cloudpickle


### PR DESCRIPTION
Related to https://github.com/cesium-ml/cesium/pull/276 https://github.com/cesium-ml/cesium/issues/277.

I think this is the only places where `get` was used. I updated the `requirements.txt`.