### PR TITLE
Added version capping for dask

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,7 +2,7 @@ numpy>=1.14.3
 scipy>=0.16.0
 scikit-learn>=0.18.1
 pandas>=0.17.0
-dask>=1.0.0
+dask>=1.0.0,<2.5.0
 toolz
 gatspy>=0.3.0
 cloudpickle


### PR DESCRIPTION
Added a cap on the dask version to ensure Cesium works with the 2.5.0 release on pypi (By only installing versioning smaller than it).

I noticed it erroring out on multiple travis environments, so I assume the issue is widespread (cesium version 0.9.9).

See issue #286  for more details.