### PR TITLE
Update README.md Windows installation instructions

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,13 +16,14 @@ More information and [examples](http://cesium-ml.org/docs/auto_examples/index.ht
 
 ## Installation from binaries:
 - Wheels for Mac and Linux can be installed via `pip install cesium`.
+- We do not build binary wheels for Windows. To install on Windows, follow the instructions below for installation from source.
 
 ## Installation from source:
 1. Install [Cython](http://cython.readthedocs.io/en/latest/src/quickstart/install.html)
 2. Clone the repository: `git clone https://github.com/cesium-ml/cesium.git`
 3. `cd cesium && pip install -e .`
 
-Note that cesium requires a C99 compiler, which in particular excludes MSVC. On Windows, a different compiler like MinGW has to be used.
+Note that cesium requires a C99 compiler, which in particular excludes MSVC. On Windows, a different compiler like MinGW has to be used. Please see the following instructions for installing Cython & MinGW on Windows: https://cython.readthedocs.io/en/latest/src/tutorial/appendix.html#appendix-installing-mingw-on-windows
 
 ## License:
 `cesium` uses the 3-clause BSD licence. The full license may be found in LICENSE.txt.


### PR DESCRIPTION
This PR makes it more explicit that Windows installation requires installing from source, as we don't build Windows binary wheels.