### PR TITLE
The test suite fails with pandas 2.0; pin to <2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,7 +1,7 @@
 numpy>=1.14.3
 scipy>=0.16.0
 scikit-learn>=0.22.1
-pandas>=0.17.0
+pandas>=0.17.0,<2
 dask>=2.5.0
 toolz
 gatspy>=0.3.0


### PR DESCRIPTION
Longer term solution:

(1) Find out if the pandas change was intentional (see https://github.com/pandas-dev/pandas/issues/52712)
(2) If so, do an audit of `.values` assignments, and re-release with pin removed

Closes #318 